### PR TITLE
Chore/faster ci builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,19 +3,43 @@ name: wheels
 on: [push, pull_request]
 
 jobs:
+  generate-wheels-matrix:
+    name: Generate wheels matrix
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set-matrix.outputs.include }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install cibuildwheel
+        run: pipx install cibuildwheel==2.12.0
+      - id: set-matrix
+        run: |
+          MATRIX=$(
+            {
+              cibuildwheel --print-build-identifiers --platform linux \
+              | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos \
+              | jq -nRc '{"only": inputs, "os": "macos-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows \
+              | jq -nRc '{"only": inputs, "os": "windows-latest"}'
+            } | jq -sc
+          )
+          echo "include=$MATRIX" >> $GITHUB_OUTPUT
+
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.only }}
+    needs: generate-wheels-matrix
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        include: ${{ fromJson(needs.generate-wheels-matrix.outputs.include) }}
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.5.0
+        uses: pypa/cibuildwheel@v2.12.0
         with:
           package-dir: ./
           output-dir: ./wheelhouse

--- a/pybind11/README.rst
+++ b/pybind11/README.rst
@@ -122,7 +122,7 @@ Supported compilers
 1. Clang/LLVM 3.3 or newer (for Apple Xcode's clang, this is 5.0.0 or
    newer)
 2. GCC 4.8 or newer
-3. Microsoft Visual Studio 2017 or newer
+3. Microsoft Visual Studio 17 2022 or newer
 4. Intel classic C++ compiler 18 or newer (ICC 20.2 tested in CI)
 5. Cygwin/GCC (previously tested on 2.5.1)
 6. NVCC (CUDA 11.0 tested in CI)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ before-build = """\
   cd ./ogdf-conda/src && \
   mkdir build && \
   cd build && \
-  cmake .. -DCMAKE_GENERATOR="Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX=C:/ogdf/ -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_BUILD_TYPE=Release && \
+  cmake .. -DCMAKE_GENERATOR="Visual Studio 17 2022" -DCMAKE_INSTALL_PREFIX=C:/ogdf/ -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_BUILD_TYPE=Release && \
   cmake --build . --config Release --target install -- /m && \
   cd .. && \
   rmdir /Q /S build\

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 [tool.cibuildwheel]
 # Skip 32-bit builds, musl build, and pypy builds
-skip = ["*-win32", "*-manylinux_i686", "*-musllinux_*", "*pypy*"]
+skip = ["*-win32", "*-manylinux_i686", "*-musllinux_*", "pp*", "*p36-*", "*p37-*", "*p38-*"]
 
 
 [tool.cibuildwheel.linux]

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ class CMakeBuild(build_ext):
             cmake_args += [
                 "-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), extdir)
             ]
-            cmake_args += ["-G", "Visual Studio 16 2019"]
+            cmake_args += ["-G", "Visual Studio 17 2022"]
             cmake_args += ["-A", "x64"]
             cmake_args += ["-T", "ClangCL"]
             build_args += ["--", "/m"]


### PR DESCRIPTION
This chore branch splits the github actions per wheel, instead of per platform.

This has the effect of parallelising the builds, building each wheel target in its own Ci runner instance. This in turn means builds are as fast as the slowest *single* wheel, instead of the N wheels built in serial on the slowest platform. This reduces Ci complexity from O(N*K) to O(N).

In concrete terms we get a result in under 1 hours instead of over 5 hours.