### PR TITLE
chore(arm64): support osx apple silicon m1/m2 builds and linux aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,17 @@ See <a href="http://tmap.gdb.tools">http://tmap.gdb.tools</a>
 
 
 ### Availability
-| Language | Operating System       | Status                  |
-| -------- | ---------------------- | ----------------------- |
-| Python   | Linux (x86_64)         | Available               |
-|          | Linux (arm64)          | Unavailable<sup>1</sup> |
-|          | Windows                | Available<sup>2</sup>   |
-|          | macOS (intel)          | Available               |
-|          | macOS (silicon/arm64)  | Unavailable<sup>1</sup> |
-| R        |                        | Unavailable<sup>3</sup> |
+| Language | Operating System | Status                 |
+| -------- | ---------------- | ---------------------- |
+| Python   | Linux            | Available              |
+|          | Windows          | Available<sup>1</sup>  |
+|          | macOS            | Available<sup>2</sup>              |
+| R        |                  | Unvailable<sup>3</sup> |
 
-<span class="small"><sup>1</sup>Arm64 build support is in the works. PRs welcome!</span>
-<span class="small"><sup>2</sup>Works with
-[WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10)</span>
+<span class="small"><sup>1</sup>Works with
+[WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10)</span>  
+<span class="small"><sup>2</sup>Pip 20.3+ is required as we build universal2 for M1 support
+[cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/faq/)\!</span>
 <span class="small"><sup>3</sup>FOSS R developers
 [wanted](https://github.com/reymond-group/tmap)\!</span>
 

--- a/ogdf-conda/src/cmake/compiler-specifics.cmake
+++ b/ogdf-conda/src/cmake/compiler-specifics.cmake
@@ -15,7 +15,8 @@ endif()
 # use native arch (ie, activate things like SSE)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm")
   # cannot use add_definitions() here because it does not work with check-sse3.cmake
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -mno-avx512f")
+  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -mno-avx512f")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-avx512f")
 endif()
 
 # set default warning flags for OGDF and tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ maintainers = [
 skip = ["*-manylinux_i686", "*-musllinux_*", "pp*", "*p36-*", "*p37-*", "*p38-*"]
 
 [tool.cibuildwheel.linux]
+# Build `aarch64` (arm64) and `amd64` on linux
+archs = ["x86_64", "aarch64"]
 before-build = """\
   cd ./ogdf-conda/src && \
   mkdir build && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ maintainers = [
 [tool.cibuildwheel]
 # Skip 32-bit builds, musl build, and pypy builds
 skip = ["*-manylinux_i686", "*-musllinux_*", "pp*", "*p36-*", "*p37-*", "*p38-*"]
+build = "cp310-*"
 
 [tool.cibuildwheel.linux]
 # Build `aarch64` (arm64) and `amd64` on linux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ before-build = """\
   cd build && \
   cmake .. \
         -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DBUILD_SHARED_LIBS=ON \
         && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ before-build = """\
   """
 
 [tool.cibuildwheel.macos]
+# Build `universal2` which contains `arm64` and `intel` wheels but only works with
+# pip 20.3+
+archs = ["universal2"]
 before-all = ["brew install libomp"]
 before-build = """\
   cd ./ogdf-conda/src && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,15 +52,15 @@ before-build = """\
   rm -r build \
   """
 repair-wheel-command = [
-  "DYLD_LIBRARY_PATH=/usr/local/lib delocate-listdeps {wheel}",
-  "DYLD_LIBRARY_PATH=/usr/local/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}",
+  "DYLD_LIBRARY_PATH=$(brew --prefix)/lib delocate-listdeps {wheel}",
+  "DYLD_LIBRARY_PATH=$(brew --prefix)/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}",
 ]
 
 [tool.cibuildwheel.macos.environment]
-LDFLAGS = "-L/usr/local/lib"
-CFLAGS = "-I/usr/local/include"
-CXX = "/usr/local/opt/llvm/bin/clang++"
-CC = "/usr/local/opt/llvm/bin/clang"
+LDFLAGS = "-L$(brew --prefix)/lib"
+CFLAGS = "-I$(brew --prefix)/include"
+CXX="$(brew --prefix llvm)/bin/clang++"
+CC="$(brew --prefix llvm)/bin/clang"
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ class CMakeBuild(build_ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
+            "-DCMAKE_OSX_ARCHITECTURES=\"x86_64;arm64\"",
             "-DPYTHON_EXECUTABLE=" + sys.executable,
             "-DPYBIND11_CPP_STANDARD=/std:c++17",
         ]


### PR DESCRIPTION
This PR adds support for 64bit arm cpus i.e. apple silicon and linux aarch64.

We achieve this by:

 - using `universal2` OSX wheel types which limits use to `pip 20.3+`
 - enabling `aarch64` on linux 

We don't yet build arm64 on windows as we don't have a usecase (PRs welcome).