### PR TITLE
Removed debug output from layout.cc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name="tmap-viz",
-    version="1.0.17",
+    version="1.0.18",
     author="Daniel Probst",
     author_email="daenuprobst@gmail.com",
     description="A Python package for visualizing large, high-dimensional data sets.",

--- a/src/_tmap/layout.cc
+++ b/src/_tmap/layout.cc
@@ -778,7 +778,6 @@ tmap::LayoutInternal(EdgeWeightedGraph<float> &g,
   {
     x[i] = ga.x(v);
     y[i] = ga.y(v);
-    std::cout << x[i] << std::endl;
     i++;
   }
 


### PR DESCRIPTION
I've realised that I left this debug output in the C++ code that outputs the x coordinate during layout computation.