### PR TITLE
chore(arm64-build): fixes the env-flags for cibuildwheel.macos on m1 …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,15 +47,15 @@ before-build = """\
   rm -r build \
   """
 repair-wheel-command = [
-  "DYLD_LIBRARY_PATH=/usr/local/lib delocate-listdeps {wheel}",
-  "DYLD_LIBRARY_PATH=/usr/local/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}",
+  "DYLD_LIBRARY_PATH=$(brew --prefix)/lib delocate-listdeps {wheel}",
+  "DYLD_LIBRARY_PATH=$(brew --prefix)/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}",
 ]
 
 [tool.cibuildwheel.macos.environment]
-LDFLAGS = "-L/usr/local/lib"
-CFLAGS = "-I/usr/local/include"
-CXX = "/usr/local/opt/llvm/bin/clang++"
-CC = "/usr/local/opt/llvm/bin/clang"
+LDFLAGS = "-L$(brew --prefix)/lib"
+CFLAGS = "-I$(brew --prefix)/include"
+CXX="$(brew --prefix llvm)/bin/clang++"
+CC="$(brew --prefix llvm)/bin/clang"
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]


### PR DESCRIPTION
…AND intel-osx machines

This is needed for building locally.