### PR TITLE
Chore/upgrade cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,11 +32,16 @@ jobs:
     needs: generate-wheels-matrix
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         include: ${{ fromJson(needs.generate-wheels-matrix.outputs.include) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.11.2
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.0
@@ -44,6 +49,7 @@ jobs:
           package-dir: ./
           output-dir: ./wheelhouse
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 # keywords = ["one", "two"]
 # license = { text = "BSD 3-Clause License" }
 # classifiers = ["Framework :: Django", "Programming Language :: Python :: 3"]
-dependencies = ["matplotlib", "annoy ~= 1.17.0"]
+dependencies = ["matplotlib", "annoy ~= 1.17.0", "scipy"]
 dynamic = ["version"]
 authors = [
   {"name" = "Daniel Probst", "email" = "daenuprobst@gmail.com"},


### PR DESCRIPTION
Upgrades the cibuildwheel deps so we can build silicon arm64 wheels:

From the release notes for [cibuildwheel](https://github.com/pypa/cibuildwheel/releases/tag/v2.12.0)
✨ Adds support for PyPy arm64 wheels. This means that you can build PyPy wheels for Apple Silicon machines. Cross-compilation is not supported for these wheels, so you'll have to build on an Apple Silicon machine. (https://github.com/pypa/cibuildwheel/pull/1372)