### PR TITLE
Chore/specify arch on osx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# message( FATAL_ERROR "some error")
 cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,16 @@ if(MSVC)
     set(CMAKE_GENERATOR_TOOLSET "ClangCL")
 endif(MSVC)
 
+if(DEFINED ENV{ARCHFLAGS})
+  # Parse the cibuildwheel ARCHFLAGS env variable as something we can understand on
+  #  OSX, initially.
+  string(REPLACE "-arch " "" NEW_ARCHFLAGS $ENV{ARCHFLAGS})
+  string(REPLACE " " ";" NEW_ARCHFLAGS "${NEW_ARCHFLAGS}")
+
+  # The following, CMAKE_OSX_ARCHITECTURES, is ignored on non-osx platforms
+  set(CMAKE_OSX_ARCHITECTURES "${NEW_ARCHFLAGS}")
+endif(DEFINED ENV{ARCHFLAGS})
+
 project(_tmap)
 
 # Put LIBOGDF on the include- and lib-path

--- a/ogdf-conda/src/CMakeLists.txt
+++ b/ogdf-conda/src/CMakeLists.txt
@@ -4,6 +4,16 @@ project(OGDF-PROJECT CXX)
 set(module_dir "${PROJECT_SOURCE_DIR}/cmake")
 list(INSERT CMAKE_MODULE_PATH 0 "${module_dir}" )
 
+if(DEFINED ENV{ARCHFLAGS})
+  # Parse the cibuildwheel ARCHFLAGS env variable as something we can understand on
+  #  OSX, initially.
+  string(REPLACE "-arch " "" NEW_ARCHFLAGS $ENV{ARCHFLAGS})
+  string(REPLACE " " ";" NEW_ARCHFLAGS "${NEW_ARCHFLAGS}")
+
+  # The following, CMAKE_OSX_ARCHITECTURES, is ignored on non-osx platforms
+  set(CMAKE_OSX_ARCHITECTURES "${NEW_ARCHFLAGS}")
+endif(DEFINED ENV{ARCHFLAGS})
+
 # build type configuration
 set(BUILD_TYPES Debug Release)
 if(CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
Specifies the archs we intend to build on OSX so that we can, hopefully, cross-compile AMD64 and ARM64