### PR TITLE
Chore/build arm64 wheels for osx

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,17 @@ See <a href="http://tmap.gdb.tools">http://tmap.gdb.tools</a>
 
 
 ### Availability
-| Language | Operating System       | Status                  |
-| -------- | ---------------------- | ----------------------- |
-| Python   | Linux (x86_64)         | Available               |
-|          | Linux (arm64)          | Unavailable<sup>1</sup> |
-|          | Windows                | Available<sup>2</sup>   |
-|          | macOS (intel)          | Available               |
-|          | macOS (silicon/arm64)  | Unavailable<sup>1</sup> |
-| R        |                        | Unavailable<sup>3</sup> |
+| Language | Operating System | Status                 |
+| -------- | ---------------- | ---------------------- |
+| Python   | Linux            | Available              |
+|          | Windows          | Available<sup>1</sup>  |
+|          | macOS            | Available<sup>2</sup>              |
+| R        |                  | Unvailable<sup>3</sup> |
 
-<span class="small"><sup>1</sup>Arm64 build support is in the works. PRs welcome!</span>
-<span class="small"><sup>2</sup>Works with
-[WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10)</span>
+<span class="small"><sup>1</sup>Works with
+[WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10)</span>  
+<span class="small"><sup>2</sup>Pip 20.3+ is required as we build universal2 for M1 support
+[cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/faq/)\!</span>
 <span class="small"><sup>3</sup>FOSS R developers
 [wanted](https://github.com/reymond-group/tmap)\!</span>
 

--- a/ogdf-conda/src/cmake/compiler-specifics.cmake
+++ b/ogdf-conda/src/cmake/compiler-specifics.cmake
@@ -13,7 +13,7 @@ if(MSVC)
 endif()
 
 # use native arch (ie, activate things like SSE)
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm" AND NOT "${CMAKE_OSX_ARCHITECTURES}" MATCHES "arm64")
   # cannot use add_definitions() here because it does not work with check-sse3.cmake
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -mno-avx512f")
 endif()

--- a/pybind11/CMakeLists.txt
+++ b/pybind11/CMakeLists.txt
@@ -41,6 +41,16 @@ project(
   LANGUAGES CXX
   VERSION "${PYBIND11_VERSION_MAJOR}.${PYBIND11_VERSION_MINOR}.${PYBIND11_VERSION_PATCH}")
 
+if(DEFINED ENV{ARCHFLAGS})
+  # Parse the cibuildwheel ARCHFLAGS env variable as something we can understand on
+  #  OSX, initially.
+  string(REPLACE "-arch " "" NEW_ARCHFLAGS $ENV{ARCHFLAGS})
+  string(REPLACE " " ";" NEW_ARCHFLAGS "${NEW_ARCHFLAGS}")
+
+  # The following, CMAKE_OSX_ARCHITECTURES, is ignored on non-osx platforms
+  set(CMAKE_OSX_ARCHITECTURES "${NEW_ARCHFLAGS}")
+endif(DEFINED ENV{ARCHFLAGS})
+
 # Standard includes
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ before-build = """\
 LIBOGDF_INSTALL_PATH="$(pwd)/libOGDF"
 
 [tool.cibuildwheel.macos]
+# Build `universal2` which contains `arm64` and `intel` wheels but only works with
+# pip 20.3+
+archs = ["universal2"]
 before-all = ["brew install libomp"]
 before-build = """\
   mkdir -p $LIBOGDF_INSTALL_PATH && \


### PR DESCRIPTION
Addresses #35 (you can install from the latest action on master, until we publish to pypi) and fixes #33

Finally we build (cross-compiled) m1 compatible wheels in github actions.

