### PR TITLE
Fix/pybind .so not building multi arch libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,12 @@ See <a href="http://tmap.gdb.tools">http://tmap.gdb.tools</a>
 | -------- | ---------------- | ---------------------- |
 | Python   | Linux            | Available              |
 |          | Windows          | Available<sup>1</sup>  |
-|          | macOS            | Available<sup>2</sup>              |
-| R        |                  | Unvailable<sup>3</sup> |
+|          | macOS            | Available              |
+| R        |                  | Unvailable<sup>2</sup> |
 
 <span class="small"><sup>1</sup>Works with
-[WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10)</span>  
-<span class="small"><sup>2</sup>Pip 20.3+ is required as we build universal2 for M1 support
-[cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/faq/)\!</span>
-<span class="small"><sup>3</sup>FOSS R developers
+[WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10)</span>
+<span class="small"><sup>2</sup>FOSS R developers
 [wanted](https://github.com/reymond-group/tmap)\!</span>
 
 ### Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ LIBOGDF_INSTALL_PATH="$(pwd)/libOGDF"
 # not build /usr/local/lib/libOGDF.dylib under `arm64` for some reason.
 archs = ["x86_64", "arm64"]
 before-all = ["brew install libomp"]
+# NOTE: we delete build/ here as we're build multiple wheels and we support
+#       different SIMD commands on different platforms.
 before-build = """\
   mkdir -p $LIBOGDF_INSTALL_PATH && \
   cd ./ogdf-conda/src && \
@@ -50,7 +52,8 @@ before-build = """\
         && \
   make -j4 && \
   make install && \
-  cd ..
+  cd .. && \
+  rm -rf build \
   """
 repair-wheel-command = [
   "DYLD_LIBRARY_PATH=$LIBOGDF_INSTALL_PATH/lib delocate-listdeps {wheel}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ LIBOGDF_INSTALL_PATH="$(pwd)/libOGDF"
 # For now build `x86_64` and `arm64` instead of `universal2` because we currently do
 # not build /usr/local/lib/libOGDF.dylib under `arm64` for some reason.
 archs = ["x86_64", "arm64"]
-before-all = ["brew install libomp"]
+before-all = ["brew install libomp llvm"]
 # NOTE: we delete build/ here as we're build multiple wheels and we support
 #       different SIMD commands on different platforms.
 before-build = """\

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ before-build = """\
 LIBOGDF_INSTALL_PATH="$(pwd)/libOGDF"
 
 [tool.cibuildwheel.macos]
-# Build `universal2` which contains `arm64` and `intel` wheels but only works with
-# pip 20.3+
-archs = ["universal2"]
+# For now build `x86_64` and `arm64` instead of `universal2` because we currently do
+# not build /usr/local/lib/libOGDF.dylib under `arm64` for some reason.
+archs = ["x86_64", "arm64"]
 before-all = ["brew install libomp"]
 before-build = """\
   mkdir -p $LIBOGDF_INSTALL_PATH && \


### PR DESCRIPTION
This fixes an issue in PR #53 where the `arm64` part of one of, and only one of, the Mach-0 binaries wasn't actually being produced on github actions!

This PR switches to separate `arm64` and `amd64` wheels because the `universal2` wheel was not being built properly using github actions because pybind11 wasn't producing a multi-arch `.so`, however when building locally more than once (as is quite likely) pybind11 would produce and merge (maybe??) the arm64 arch into the amd64 `.so`.

To fix an additional issue when building locally, this also reintroduces a change to clean the `build/` intermediary folder for OGDF, because the CMake build for one platform specifies SIMD support that isn't actually available on the 2nd build, and therefore the 2nd build would fail trying to build against the wrong SIMD intrinsics.