### PR TITLE
Fixing osx arm64 wheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -40,6 +40,14 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v3
 
+      - name: OSX Arm64 env variables
+        if: ${{ contains(matrix.only, 'macosx_arm64') }}
+        run: |
+            echo 'CMAKE_OSX_ARCHITECTURES=arm64' >> $GITHUB_ENV
+
+      - name: Env variable ${{ matrix.only }} for build
+        run: echo "CIBW_BUILD=${{ matrix.only }}"  >> $GITHUB_ENV
+
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.11.2
 

--- a/pybind11/tests/requirements.txt
+++ b/pybind11/tests/requirements.txt
@@ -1,6 +1,6 @@
 build==0.7.0
 numpy==1.21.5; platform_python_implementation=="PyPy" and sys_platform=="linux" and python_version=="3.7"
-numpy==1.19.3; platform_python_implementation!="PyPy" and python_version=="3.6"
+numpy==1.22.0; platform_python_implementation!="PyPy" and python_version=="3.6"
 numpy==1.21.5; platform_python_implementation!="PyPy" and python_version>="3.7" and python_version<"3.10"
 numpy==1.22.2; platform_python_implementation!="PyPy" and python_version>="3.10" and python_version<"3.11"
 pytest==7.0.0


### PR DESCRIPTION
Hi, this PR intends to fix 2 things:
- https://github.com/reymond-group/tmap/issues/55
- all of the wheel github actions are building for all python versions, which means we are duplicating the builds

Let me know if it makes sense!
 

Tested with commit [8bc1576](https://github.com/wckdouglas/tmap/commit/8bc1576e75b47f7387a5bbe9bca715633bd4af5c), `artifact.zip` from [here](https://github.com/wckdouglas/tmap/actions/runs/5105228389)
```
$ sysctl -n machdep.cpu.brand_string
Apple M1
$ unzip artifact.zip
$ pip --version
pip 23.1.2 from /Users/../lib/python3.10/site-packages/pip (python 3.10)
$ pip install tmap_viz-1.0.18-cp310-cp310-macosx_11_0_arm64.whl --force-reinstall
$ python --version
Python 3.10.11
$ python -c "import tmap"
```