### PR TITLE
Upgraded cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ See <a href="http://tmap.gdb.tools">http://tmap.gdb.tools</a>
 ## Examples
 <img src="examples/drugbank/drugbank.jpg" height="290px"/>  <img src="examples/mnist/mnist.jpg" height="290px" />
 
-| Name | Description |   |
-| ---- | ----------- | - |
-| NIPS Conference Papers | A tmap visualization showing the linguistic relationship between NIPS conference papers. | [view](http://tmap.gdb.tools/src/nips/nips_papers.html) |
-| Project Gutenberg | A tmap visualization of the linguistic relationships between books and authors extracted from Project Gutenberg. | [view](http://tmap.gdb.tools/src/gutenberg/gutenberg.html) |
-| MNIST | A visualization of the well known MNIST data set. No further explanation needed. | [view](http://tmap.gdb.tools/src/mnist/mnist.html) |
-| Fashion MNIST | A visualization of a more fashionable variant of MNIST. | [view](http://tmap.gdb.tools/src/fmnist/fmnist.html) |
-| Drugbank | A tmap visualization of all drugs registered in Drugbank. | [view](http://tmap.gdb.tools/src/drugbank/drugbank.html) |
-| RNAseq | RNA sequencing data of tumor samples. Visualized using tmap. | [view](http://tmap.gdb.tools/src/rnaseq/rnaseq.html) |
-| Flowcytometry | Flowcytometry data visualized using tmap. | [view](http://tmap.gdb.tools/src/flowcytometry/cyto.html) |
-| MiniBooNE | tmap data visualization of a particle detection physics experiment.  | [view](http://tmap.gdb.tools/src/miniboone/miniboone.html) |
+| Name                   | Description                                                                                                      |                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| NIPS Conference Papers | A tmap visualization showing the linguistic relationship between NIPS conference papers.                         | [view](http://tmap.gdb.tools/src/nips/nips_papers.html)    |
+| Project Gutenberg      | A tmap visualization of the linguistic relationships between books and authors extracted from Project Gutenberg. | [view](http://tmap.gdb.tools/src/gutenberg/gutenberg.html) |
+| MNIST                  | A visualization of the well known MNIST data set. No further explanation needed.                                 | [view](http://tmap.gdb.tools/src/mnist/mnist.html)         |
+| Fashion MNIST          | A visualization of a more fashionable variant of MNIST.                                                          | [view](http://tmap.gdb.tools/src/fmnist/fmnist.html)       |
+| Drugbank               | A tmap visualization of all drugs registered in Drugbank.                                                        | [view](http://tmap.gdb.tools/src/drugbank/drugbank.html)   |
+| RNAseq                 | RNA sequencing data of tumor samples. Visualized using tmap.                                                     | [view](http://tmap.gdb.tools/src/rnaseq/rnaseq.html)       |
+| Flowcytometry          | Flowcytometry data visualized using tmap.                                                                        | [view](http://tmap.gdb.tools/src/flowcytometry/cyto.html)  |
+| MiniBooNE              | tmap data visualization of a particle detection physics experiment.                                              | [view](http://tmap.gdb.tools/src/miniboone/miniboone.html) |
 
 
 ### Availability
@@ -46,4 +46,12 @@ We suggest using faerun to plot the data layed out by tmap. But you can of cours
 ```bash
 pip install faerun
 # pip install matplotlib
+```
+
+### If you want to compile your own wheel
+```bash
+git clone git@github.com:reymond-group/tmap.git
+cd tmap
+uv sync
+uvx cibuildwheel --output-dir ./wheelhouse
 ```

--- a/ogdf-conda/src/CMakeLists.txt
+++ b/ogdf-conda/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 project(OGDF-PROJECT CXX)
 
 set(module_dir "${PROJECT_SOURCE_DIR}/cmake")

--- a/pybind11/CMakeLists.txt
+++ b/pybind11/CMakeLists.txt
@@ -5,7 +5,7 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 
 # The `cmake_minimum_required(VERSION 3.4...3.22)` syntax does not work with
 # some versions of VS that have a patched CMake 3.11. This forces us to emulate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,16 +7,21 @@ readme = "README.md"
 # classifiers = ["Framework :: Django", "Programming Language :: Python :: 3"]
 dependencies = ["matplotlib", "annoy ~= 1.17.0", "scipy"]
 dynamic = ["version"]
-authors = [
-  {"name" = "Daniel Probst", "email" = "daenuprobst@gmail.com"},
-]
+authors = [{ "name" = "Daniel Probst", "email" = "daenuprobst@gmail.com" }]
 maintainers = [
-  {"name" = "Frank Harrison", "email" = "doublethefish@gmail.com"},
+  { "name" = "Frank Harrison", "email" = "doublethefish@gmail.com" },
 ]
 
 [tool.cibuildwheel]
 # Skip 32-bit builds, musl build, and pypy builds
-skip = ["*-manylinux_i686", "*-musllinux_*", "pp*", "*p36-*", "*p37-*", "*p38-*"]
+skip = [
+  "*-manylinux_i686",
+  "*-musllinux_*",
+  "pp*",
+  "*p36-*",
+  "*p37-*",
+  "*p38-*",
+]
 
 [tool.cibuildwheel.linux]
 before-build = """\
@@ -31,7 +36,7 @@ before-build = """\
   """
 
 [tool.cibuildwheel.linux.environment]
-LIBOGDF_INSTALL_PATH="$(pwd)/libOGDF"
+LIBOGDF_INSTALL_PATH = "$(pwd)/libOGDF"
 
 [tool.cibuildwheel.macos]
 # For now build `x86_64` and `arm64` instead of `universal2` because we currently do
@@ -61,9 +66,9 @@ repair-wheel-command = [
 ]
 
 [tool.cibuildwheel.macos.environment]
-LIBOGDF_INSTALL_PATH="$(pwd)/libOGDF"
-CXX="$(brew --prefix llvm)/bin/clang++"
-CC="$(brew --prefix llvm)/bin/clang"
+LIBOGDF_INSTALL_PATH = "$(pwd)/libOGDF"
+CXX = "$(brew --prefix llvm)/bin/clang++"
+CC = "$(brew --prefix llvm)/bin/clang"
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]
@@ -81,4 +86,4 @@ before-build = """\
 [tool.cibuildwheel.windows.environment]
 # NOTE: if building locally you will have to build here or fixup the script to build
 #       into the tmap-viz directory.
-LIBOGDF_INSTALL_PATH="c:/libOGDF"
+LIBOGDF_INSTALL_PATH = "c:/libOGDF"


### PR DESCRIPTION
Hi there, 

Trying to compile tmap with `cmake_minimum_required<3.5` used to fail with an error saying that it is depreciated.

This pull request fixes this issue and `cibuildwheel` can now compile tmap. 

I've also added a small explanation in the README.md

Best,

Marco